### PR TITLE
NRF_Cache_Implementation

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -23,6 +23,7 @@ var (
 	DiscoveryLog   *logrus.Entry
 	GinLog         *logrus.Entry
 	GrpcLog        *logrus.Entry
+	UtilLog        *logrus.Entry
 )
 
 func init() {
@@ -46,6 +47,7 @@ func init() {
 	DiscoveryLog = log.WithFields(logrus.Fields{"component": "NRF", "category": "DSCV"})
 	GinLog = log.WithFields(logrus.Fields{"component": "NRF", "category": "GIN"})
 	GrpcLog = log.WithFields(logrus.Fields{"component": "NRF", "category": "GRPC"})
+	UtilLog = log.WithFields(logrus.Fields{"component": "NRF", "category": "Util"})
 }
 
 func SetLogLevel(level logrus.Level) {

--- a/nrfcache/match_filters.go
+++ b/nrfcache/match_filters.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2022 Infosys Limited
+// Copyright 2019 free5GC.org
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nrf_cache
+
+import (
+	"encoding/json"
+	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
+	"github.com/omec-project/openapi/models"
+	"regexp"
+)
+
+type MatchFilter func(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool
+
+type MatchFilters map[models.NfType]MatchFilter
+
+var matchFilters = MatchFilters{
+	models.NfType_SMF:  MatchSmfProfile,
+	models.NfType_AUSF: MatchAusfProfile,
+	models.NfType_PCF:  MatchPcfProfile,
+	models.NfType_NSSF: MatchNssfProfile,
+	models.NfType_UDM:  MatchUdmProfile,
+	models.NfType_AMF:  MatchAmfProfile,
+}
+
+func MatchSmfProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+
+	matchFound := true
+
+	if opts.ServiceNames.IsSet() {
+		reqServiceNames := opts.ServiceNames.Value().([]models.ServiceName)
+		matchCount := 0
+		for _, sn := range reqServiceNames {
+			for i := 0; i < len(*profile.NfServices); i++ {
+				if (*profile.NfServices)[i].ServiceName == sn {
+					matchCount++
+					break
+				}
+			}
+		}
+
+		if matchCount == 0 {
+			matchFound = false
+		}
+	}
+
+	if matchFound && opts.Snssais.IsSet() {
+		reqSnssais := opts.Snssais.Value().([]string)
+		matchCount := 0
+
+		for _, reqSnssai := range reqSnssais {
+			var snssai models.Snssai
+			err := json.Unmarshal([]byte(reqSnssai), &snssai)
+			if err != nil {
+				return false
+			}
+
+			// Snssai in the smfInfo has priority
+			if profile.SmfInfo != nil && profile.SmfInfo.SNssaiSmfInfoList != nil {
+				for _, s := range *profile.SmfInfo.SNssaiSmfInfoList {
+					if s.SNssai != nil && (*s.SNssai) == snssai {
+						matchCount++
+					}
+				}
+			} else if profile.AllowedNssais != nil {
+				for _, s := range *profile.AllowedNssais {
+					if s == snssai {
+						matchCount++
+					}
+				}
+			}
+
+		}
+
+		// if at least one matching snssai has been found
+		if matchCount == 0 {
+			matchFound = false
+		}
+
+	}
+
+	// validate dnn
+	if matchFound && opts.Dnn.IsSet() {
+		// if a dnn is provided by the upper layer, check for the exact match
+		// or wild card match
+		dnnMatched := false
+
+		if profile.SmfInfo != nil && profile.SmfInfo.SNssaiSmfInfoList != nil {
+		matchDnnLoop:
+			for _, s := range *profile.SmfInfo.SNssaiSmfInfoList {
+				if s.DnnSmfInfoList != nil {
+					for _, d := range *s.DnnSmfInfoList {
+						if d.Dnn == opts.Dnn.Value() || d.Dnn == "*" {
+							dnnMatched = true
+							break matchDnnLoop
+						}
+					}
+				}
+			}
+		}
+		matchFound = dnnMatched
+	}
+	logger.UtilLog.Tracef("SMF match found = %v", matchFound)
+	return matchFound
+}
+
+func MatchSupiRange(supi string, supiRange []models.SupiRange) bool {
+	matchCount := 0
+	for _, s := range supiRange {
+		if len(s.Pattern) > 0 {
+			r, _ := regexp.Compile(s.Pattern)
+			if r.MatchString(supi) {
+				matchCount++
+			}
+
+		} else if s.Start <= supi && supi <= s.End {
+			matchCount++
+		}
+	}
+
+	return matchCount > 0
+}
+
+func MatchAusfProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+	matchFound := true
+	if opts.Supi.IsSet() {
+		if profile.AusfInfo != nil && len(profile.AusfInfo.SupiRanges) > 0 {
+			matchFound = MatchSupiRange(opts.Supi.Value(), profile.AusfInfo.SupiRanges)
+		}
+	}
+	logger.UtilLog.Tracef("Ausf match found = %v", matchFound)
+	return matchFound
+}
+
+func MatchNssfProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+	logger.UtilLog.Traceln("Nssf match found ")
+	return true
+}
+
+func MatchAmfProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+	logger.UtilLog.Traceln("Amf match found ")
+	return true
+}
+
+func MatchPcfProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+	matchFound := true
+	if opts.Supi.IsSet() {
+		if profile.PcfInfo != nil && len(profile.PcfInfo.SupiRanges) > 0 {
+			matchFound = MatchSupiRange(opts.Supi.Value(), profile.PcfInfo.SupiRanges)
+		}
+	}
+	logger.UtilLog.Tracef("PCF match found = %v", matchFound)
+	return matchFound
+}
+
+func MatchUdmProfile(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool {
+	matchFound := true
+	if opts.Supi.IsSet() {
+		if profile.UdmInfo != nil && len(profile.UdmInfo.SupiRanges) > 0 {
+			matchFound = MatchSupiRange(opts.Supi.Value(), profile.UdmInfo.SupiRanges)
+		}
+	}
+	logger.UtilLog.Tracef("UDM match found = %v", matchFound)
+	return matchFound
+}

--- a/nrfcache/match_filters.go
+++ b/nrfcache/match_filters.go
@@ -8,10 +8,11 @@ package nrf_cache
 
 import (
 	"encoding/json"
-	"github.com/omec-project/amf/logger"
+	"regexp"
+
+	"github.com/omec-project/nrf/logger"
 	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
 	"github.com/omec-project/openapi/models"
-	"regexp"
 )
 
 type MatchFilter func(profile *models.NfProfile, opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) bool

--- a/nrfcache/nrf_cache.go
+++ b/nrfcache/nrf_cache.go
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2022 Infosys Limited
+// Copyright 2019 free5GC.org
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package nrf_cache
+
+import (
+	"container/heap"
+	"encoding/json"
+	"github.com/omec-project/amf/logger"
+	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
+	"github.com/omec-project/openapi/models"
+	"sync"
+	"time"
+)
+
+const defaultCacheTTl = time.Hour
+const defaultNfProfileTTl = time.Minute
+
+type NfProfileItem struct {
+	nfProfile  *models.NfProfile
+	ttl        time.Duration
+	expiryTime time.Time
+	index      int // index of the entry in the priority queue
+}
+
+func (item *NfProfileItem) isExpired() bool {
+	return item.expiryTime.Before(time.Now())
+}
+
+func (item *NfProfileItem) updateExpiryTime() {
+	item.expiryTime = time.Now().Add(time.Second * item.ttl)
+}
+
+func newNfProfileItem(profile *models.NfProfile, ttl time.Duration) *NfProfileItem {
+	item := &NfProfileItem{
+		nfProfile: profile,
+		ttl:       ttl,
+	}
+	// since nobody is aware yet of this item, it's safe to touch without lock here
+	item.updateExpiryTime()
+	return item
+}
+
+// NfProfilePriorityQ : Priority Queue to store the profile by expiry time
+type NfProfilePriorityQ []*NfProfileItem
+
+func (npq NfProfilePriorityQ) Len() int {
+	return len(npq)
+}
+
+func (npq NfProfilePriorityQ) Less(i, j int) bool {
+	return npq[i].expiryTime.Before(npq[j].expiryTime)
+}
+
+func (npq NfProfilePriorityQ) Swap(i, j int) {
+	npq[i], npq[j] = npq[j], npq[i]
+	npq[i].index = i
+	npq[j].index = j
+}
+
+func (npq NfProfilePriorityQ) root() *NfProfileItem {
+	return npq[0]
+}
+
+func (npq NfProfilePriorityQ) at(index int) *NfProfileItem {
+	return npq[index]
+}
+
+func (npq *NfProfilePriorityQ) push(item interface{}) {
+	heap.Push(npq, item)
+}
+
+func (npq *NfProfilePriorityQ) pop() interface{} {
+	if npq.Len() == 0 {
+		return nil
+	}
+	return heap.Pop(npq).(*NfProfileItem)
+}
+
+// update modifies the priority and value of an Item in the queue.
+func (npq *NfProfilePriorityQ) update(item *NfProfileItem, value *models.NfProfile, ttl time.Duration) {
+	item.nfProfile = value
+	item.ttl = ttl
+	item.updateExpiryTime()
+	heap.Fix(npq, item.index)
+}
+
+func (npq *NfProfilePriorityQ) remove(item *NfProfileItem) {
+	heap.Remove(npq, item.index)
+}
+
+func (npq *NfProfilePriorityQ) Push(item interface{}) {
+	n := len(*npq)
+	entry := item.(*NfProfileItem)
+	entry.index = n
+	*npq = append(*npq, entry)
+}
+
+func (npq *NfProfilePriorityQ) Pop() interface{} {
+	old := *npq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	item.index = -1
+	*npq = old[0 : n-1]
+	return item
+}
+
+func newNfProfilePriorityQ() *NfProfilePriorityQ {
+	q := &NfProfilePriorityQ{}
+	heap.Init(q)
+	return q
+}
+
+type NrfRequest struct {
+	targetNfType models.NfType
+	searchParams *Nnrf_NFDiscovery.SearchNFInstancesParamOpts
+}
+
+// NrfCache : cache of nf profiles
+type NrfCache struct {
+	cache map[string]*NfProfileItem // map[nf-instance-id] =*NfProfile
+
+	priorityQ *NfProfilePriorityQ // sorted by expiry time
+
+	evictionInterval time.Duration // timer interval in which the cache is checked for eviction of expired entries
+
+	evictionTicker *time.Ticker
+
+	nrfDiscoveryQueryCb NrfDiscoveryQueryCb // nrf query callback
+
+	done chan struct{}
+
+	mutex sync.RWMutex
+}
+
+func (c *NrfCache) handleLookup(nrfUri string, targetNfType, requestNfType models.NfType, param *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) (models.SearchResult, error) {
+	var searchResult models.SearchResult
+	var err error
+
+	c.mutex.RLock()
+	searchResult.NfInstances = c.get(param)
+	c.mutex.RUnlock()
+
+	if len(searchResult.NfInstances) == 0 {
+		logger.UtilLog.Tracef("Cache miss for nftype %s", targetNfType)
+
+		c.mutex.Lock()
+		searchResult.NfInstances = c.get(param)
+		if len(searchResult.NfInstances) == 0 {
+			searchResult, err = c.nrfDiscoveryQueryCb(nrfUri, targetNfType, requestNfType, param)
+			if err != nil {
+				return searchResult, err
+			}
+
+			for i := 0; i < len(searchResult.NfInstances); i++ {
+				c.set(&searchResult.NfInstances[i], time.Duration(searchResult.ValidityPeriod))
+			}
+		}
+		c.mutex.Unlock()
+	}
+	return searchResult, err
+}
+
+func (c *NrfCache) set(nfProfile *models.NfProfile, ttl time.Duration) {
+	if ttl == 0 {
+		ttl = defaultNfProfileTTl
+	}
+
+	item, exists := c.cache[nfProfile.NfInstanceId]
+	if exists {
+		// if item.isExpired()
+		c.priorityQ.update(item, nfProfile, ttl)
+	} else {
+		newItem := newNfProfileItem(nfProfile, ttl)
+		c.cache[nfProfile.NfInstanceId] = newItem
+		c.priorityQ.push(newItem)
+	}
+}
+
+func (c *NrfCache) get(opts *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) []models.NfProfile {
+	var nfProfiles []models.NfProfile
+
+	for _, element := range c.cache {
+		if !element.isExpired() {
+			if opts != nil {
+				cb, ok := matchFilters[element.nfProfile.NfType]
+				if ok && cb(element.nfProfile, opts) {
+					nfProfiles = append(nfProfiles, *(element.nfProfile))
+				}
+			} else {
+				nfProfiles = append(nfProfiles, *(element.nfProfile))
+			}
+		}
+	}
+	return nfProfiles
+}
+
+func (c *NrfCache) remove(item *NfProfileItem) {
+	c.priorityQ.remove(item)
+	delete(c.cache, item.nfProfile.NfInstanceId)
+}
+
+func (c *NrfCache) cleanupExpiredItems() {
+	logger.UtilLog.Infoln("nrf cache: cleanup expired items")
+
+	for item := c.priorityQ.at(0); item.isExpired(); {
+
+		logger.UtilLog.Tracef("evicted nf instance %s", item.nfProfile.NfInstanceId)
+
+		c.remove(item)
+		if c.priorityQ.Len() == 0 {
+			break
+		} else {
+			item = c.priorityQ.at(0)
+		}
+	}
+}
+
+func (c *NrfCache) purge() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	close(c.done)
+	c.priorityQ = newNfProfilePriorityQ()
+	c.cache = make(map[string]*NfProfileItem)
+	c.evictionTicker.Stop()
+}
+
+func (c *NrfCache) startExpiryProcessing() {
+	for {
+		select {
+		case <-c.evictionTicker.C:
+			c.mutex.Lock()
+			if c.priorityQ.Len() == 0 {
+				c.mutex.Unlock()
+				continue
+			}
+
+			c.cleanupExpiredItems()
+			c.mutex.Unlock()
+
+		case <-c.done:
+			return
+		}
+	}
+}
+
+func NewNrfCache(duration time.Duration, dbqueryCb NrfDiscoveryQueryCb) *NrfCache {
+	cache := &NrfCache{
+		cache:               make(map[string]*NfProfileItem),
+		priorityQ:           newNfProfilePriorityQ(),
+		evictionInterval:    defaultCacheTTl,
+		nrfDiscoveryQueryCb: dbqueryCb,
+		done:                make(chan struct{}),
+	}
+
+	cache.evictionTicker = time.NewTicker(duration)
+
+	go cache.startExpiryProcessing()
+
+	return cache
+}
+
+func copyNrfProfile(src *models.NfProfile) (*models.NfProfile, error) {
+	nrfProfileJSON, err := json.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+	nrfProfile := models.NfProfile{}
+	if err = json.Unmarshal(nrfProfileJSON, &nrfProfile); err != nil {
+		return nil, err
+	}
+
+	return &nrfProfile, nil
+}
+
+type NrfMasterCache struct {
+	nfTypeToCacheMap    map[models.NfType]*NrfCache
+	evictionInterval    time.Duration
+	nrfDiscoveryQueryCb NrfDiscoveryQueryCb
+
+	mutex sync.Mutex
+}
+
+func (c *NrfMasterCache) GetNrfCacheInstance(targetNfType models.NfType) *NrfCache {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	cache, exists := c.nfTypeToCacheMap[targetNfType]
+	if exists == false {
+		logger.UtilLog.Infof("Creating cache for nftype %v", targetNfType)
+
+		cache = NewNrfCache(c.evictionInterval, c.nrfDiscoveryQueryCb)
+		c.nfTypeToCacheMap[targetNfType] = cache
+	}
+	return cache
+}
+
+func (c *NrfMasterCache) clearNrfCache(nfType models.NfType) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	cache, exists := c.nfTypeToCacheMap[nfType]
+	if exists == true {
+		cache.purge()
+		delete(c.nfTypeToCacheMap, nfType)
+	}
+}
+
+func (c *NrfMasterCache) clearNrfMasterCache() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for k, cache := range c.nfTypeToCacheMap {
+		cache.purge()
+		delete(c.nfTypeToCacheMap, k)
+	}
+}
+
+var masterCache *NrfMasterCache
+
+type NrfDiscoveryQueryCb func(nrfUri string, targetNfType, requestNfType models.NfType, param *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) (models.SearchResult, error)
+
+func InitNrfCaching(interval time.Duration, cb NrfDiscoveryQueryCb) {
+	m := &NrfMasterCache{
+		nfTypeToCacheMap:    make(map[models.NfType]*NrfCache),
+		evictionInterval:    interval,
+		nrfDiscoveryQueryCb: cb,
+	}
+	masterCache = m
+}
+
+func DisableNrfCaching() {
+	masterCache.clearNrfMasterCache()
+	masterCache = nil
+}
+
+func SearchNFInstances(nrfUri string, targetNfType, requestNfType models.NfType, param *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) (models.SearchResult, error) {
+
+	logger.UtilLog.Traceln("SearchNFInstances nrf cache")
+
+	var searchResult models.SearchResult
+	var err error
+
+	c := masterCache.GetNrfCacheInstance(targetNfType)
+	if c != nil {
+		searchResult, err = c.handleLookup(nrfUri, targetNfType, requestNfType, param)
+	} else {
+		logger.UtilLog.Errorln("Failed to find cache for nftype")
+	}
+
+	for _, np := range searchResult.NfInstances {
+		logger.UtilLog.Tracef("%v", np)
+	}
+
+	return searchResult, err
+
+}

--- a/nrfcache/nrf_cache.go
+++ b/nrfcache/nrf_cache.go
@@ -9,11 +9,12 @@ package nrf_cache
 import (
 	"container/heap"
 	"encoding/json"
-	"github.com/omec-project/amf/logger"
-	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
-	"github.com/omec-project/openapi/models"
 	"sync"
 	"time"
+
+	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
+	"github.com/omec-project/openapi/models"
 )
 
 const defaultCacheTTl = time.Hour

--- a/nrfcache/nrf_cache_test.go
+++ b/nrfcache/nrf_cache_test.go
@@ -1,0 +1,763 @@
+// SPDX-FileCopyrightText: 2022 Open Networking Foundation <info@opennetworking.org>
+// Copyright 2019 free5GC.org
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package nrf_cache
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/antihax/optional"
+	"github.com/omec-project/amf/util"
+	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
+	"github.com/omec-project/openapi/models"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+var nfProfilesDb map[string]string
+var validityPeriod int32
+var evictionInterval int32
+var nrfDbCallbackCallCount int32
+
+func init() {
+
+	validityPeriod = 60
+	evictionInterval = 120
+
+	nrfDbCallbackCallCount = 0
+
+	nfProfilesDb = make(map[string]string)
+
+	nfProfilesDb["SMF-010203-internet"] = `{
+		  "ipv4Addresses": [
+			"smf"
+		  ],
+		  "allowedPlmns": [
+			{
+			  "mcc": "208",
+			  "mnc": "93"
+			}
+		  ],
+		  "smfInfo": {
+			"sNssaiSmfInfoList": [
+			  {
+				"sNssai": {
+				  "sst": 1,
+				  "sd": "010203"
+				},
+				"dnnSmfInfoList": [
+				  {
+					"dnn": "internet"
+				  }
+				]
+			  }
+			]
+		  },
+		  "nfServices": [
+			{
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "b926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-pdusession",
+			  "serviceName": "nsmf-pdusession",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ],
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED"
+			},
+			{
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED",
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "b926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-event-exposure",
+			  "serviceName": "nsmf-event-exposure",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ]
+			}
+		  ],
+		  "nfInstanceId": "b926f193-1083-49a8-adb3-5fcf57a1f0bf",
+		  "plmnList": [
+			{
+			  "mnc": "93",
+			  "mcc": "208"
+			}
+		  ],
+		  "sNssais": [
+			{
+			  "sd": "010203",
+			  "sst": 1
+			}
+		  ],
+		  "nfType": "SMF",
+		  "nfStatus": "REGISTERED"
+		}`
+	nfProfilesDb["SMF-010203-ims"] = `{
+		  "ipv4Addresses": [
+			"smf"
+		  ],
+		  "allowedPlmns": [
+			{
+			  "mcc": "208",
+			  "mnc": "93"
+			}
+		  ],
+		  "smfInfo": {
+			"sNssaiSmfInfoList": [
+			  {
+				"sNssai": {
+				  "sst": 1,
+				  "sd": "010203"
+				},
+				"dnnSmfInfoList": [
+				  {
+					"dnn": "ims"
+				  }
+				]
+			  }
+			]
+		  },
+		  "nfServices": [
+			{
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "c926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-pdusession",
+			  "serviceName": "nsmf-pdusession",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ],
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED"
+			},
+			{
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED",
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "c926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-event-exposure",
+			  "serviceName": "nsmf-event-exposure",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ]
+			}
+		  ],
+		  "nfInstanceId": "c926f193-1083-49a8-adb3-5fcf57a1f0bf",
+		  "plmnList": [
+			{
+			  "mnc": "93",
+			  "mcc": "208"
+			}
+		  ],
+		  "sNssais": [
+			{
+			  "sd": "010203",
+			  "sst": 1
+			}
+		  ],
+		  "nfType": "SMF",
+		  "nfStatus": "REGISTERED"
+		}
+`
+	nfProfilesDb["SMF-0a0b0c-internet"] = `{
+		  "ipv4Addresses": [
+			"smf"
+		  ],
+		  "allowedPlmns": [
+			{
+			  "mcc": "208",
+			  "mnc": "93"
+			}
+		  ],
+		  "smfInfo": {
+			"sNssaiSmfInfoList": [
+			  {
+				"sNssai": {
+				  "sst": 1,
+				  "sd": "0a0b0c"
+				},
+				"dnnSmfInfoList": [
+				  {
+					"dnn": "internet"
+				  }
+				]
+			  }
+			]
+		  },
+		  "nfServices": [
+			{
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "d926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-pdusession",
+			  "serviceName": "nsmf-pdusession",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ],
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED"
+			},
+			{
+			  "scheme": "https",
+			  "nfServiceStatus": "REGISTERED",
+			  "apiPrefix": "http://smf:29502",
+			  "allowedPlmns": [
+				{
+				  "mcc": "208",
+				  "mnc": "93"
+				}
+			  ],
+			  "serviceInstanceId": "d926f193-1083-49a8-adb3-5fcf57a1f0bfnsmf-event-exposure",
+			  "serviceName": "nsmf-event-exposure",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "https://smf:29502/nsmf-pdusession/v1",
+				  "expiry": "2022-08-17T05:31:40.997097141Z"
+				}
+			  ]
+			}
+		  ],
+		  "nfInstanceId": "d926f193-1083-49a8-adb3-5fcf57a1f0bf",
+		  "plmnList": [
+			{
+			  "mnc": "93",
+			  "mcc": "208"
+			}
+		  ],
+		  "sNssais": [
+			{
+			  "sd": "0a0b0c",
+			  "sst": 1
+			}
+		  ],
+		  "nfType": "SMF",
+		  "nfStatus": "REGISTERED"
+		}`
+	nfProfilesDb["AUSF-1"] = `{ "nfServices": [
+			{
+			  "serviceName": "nausf-auth",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "1.0.0"
+				}
+			  ],
+			  "scheme": "http",
+			  "nfServiceStatus": "REGISTERED",
+			  "ipEndPoints": [
+				{
+				  "ipv4Address": "ausf",
+				  "port": 29509
+				}
+			  ],
+			  "serviceInstanceId": "57d0a167-5283-4170-bdd8-881076049a81"
+			}
+		  ],
+		  "ausfInfo": {
+			"supiRanges": [
+			  { "start": "123456789040000", "end": "123456789049999" }
+			]
+		  },
+		  "nfInstanceId": "57d0a167-5283-4170-bdd8-881076049a81",
+		  "nfType": "AUSF",
+		  "nfStatus": "REGISTERED",
+		  "plmnList": [
+			{
+			  "mcc": "208",
+			  "mnc": "93"
+			}
+		  ],
+		  "ipv4Addresses": [
+			"ausf"
+		  ],
+		  "ausfInfo": {
+			"groupId": "ausfGroup001"
+		  }
+		}`
+	nfProfilesDb["AUSF-2"] = `{ "nfServices": [
+			{
+			  "serviceName": "nausf-auth",
+			  "versions": [
+				{
+				  "apiVersionInUri": "v1",
+				  "apiFullVersion": "1.0.0"
+				}
+			  ],
+			  "scheme": "http",
+			  "nfServiceStatus": "REGISTERED",
+			  "ipEndPoints": [
+				{
+				  "ipv4Address": "ausf",
+				  "port": 29509
+				}
+			  ],
+			  "serviceInstanceId": "67d0a167-5283-4170-bdd8-881076049a81"
+			}
+		  ],
+		  "ausfInfo": {
+			"supiRanges": [
+			  { "pattern": "^imsi-22345678904[0-9]{4}$" }
+			]
+		  },
+		  "nfInstanceId": "67d0a167-5283-4170-bdd8-881076049a81",
+		  "nfType": "AUSF",
+		  "nfStatus": "REGISTERED",
+		  "plmnList": [
+			{
+			  "mcc": "208",
+			  "mnc": "93"
+			}
+		  ],
+		  "ipv4Addresses": [
+			"ausf"
+		  ],
+		  "ausfInfo": {
+			"groupId": "ausfGroup001"
+		  }
+		}`
+
+}
+
+func getNfProfile(key string) (models.NfProfile, error) {
+	var err error
+	var profile models.NfProfile
+
+	nfProfileStr, exists := nfProfilesDb[key]
+
+	if exists {
+		err = json.Unmarshal([]byte(nfProfileStr), &profile)
+	} else {
+		err = fmt.Errorf("failed to find nf profile for %s", key)
+	}
+
+	return profile, err
+}
+
+func getNfProfiles(targetNfType models.NfType) ([]models.NfProfile, error) {
+	var nfProfiles []models.NfProfile
+
+	for key, elem := range nfProfilesDb {
+		if strings.Contains(key, string(targetNfType)) {
+
+			var profile models.NfProfile
+			err := json.Unmarshal([]byte(elem), &profile)
+			if err != nil {
+				return nil, err
+			}
+
+			nfProfiles = append(nfProfiles, profile)
+		}
+	}
+
+	return nfProfiles, nil
+}
+
+func nrfDbCallback(nrfUri string, targetNfType, requestNfType models.NfType,
+	param *Nnrf_NFDiscovery.SearchNFInstancesParamOpts) (models.SearchResult, error) {
+	fmt.Println("nrfDbCallback Entry")
+
+	nrfDbCallbackCallCount++
+
+	var searchResult models.SearchResult
+	var nfProfile models.NfProfile
+	var err error
+	var key string
+
+	searchResult.ValidityPeriod = validityPeriod
+
+	if targetNfType == models.NfType_SMF {
+		key = "SMF"
+
+		if param != nil {
+			if param.Snssais.IsSet() {
+				snssais := param.Snssais.Value().([]string)
+
+				var snssai models.Snssai
+				err := json.Unmarshal([]byte(snssais[0]), &snssai)
+				if err != nil {
+					err = fmt.Errorf("snssai invalid %s", snssais[0])
+					return searchResult, err
+				}
+
+				key += "-" + snssai.Sd
+			}
+			if param.Dnn.IsSet() == true {
+				key += "-" + param.Dnn.Value()
+			}
+
+			nfProfile, err = getNfProfile(key)
+			if err != nil {
+				return searchResult, err
+			}
+
+			searchResult.NfInstances = append(searchResult.NfInstances, nfProfile)
+
+		} else {
+			searchResult.NfInstances, err = getNfProfiles(targetNfType)
+		}
+	} else if targetNfType == models.NfType_AUSF {
+		searchResult.NfInstances, err = getNfProfiles(targetNfType)
+	}
+
+	return searchResult, err
+}
+
+func TestCacheMissAndHits(t *testing.T) {
+
+	var result models.SearchResult
+	var err error
+
+	expectedCallCount := nrfDbCallbackCallCount
+
+	evictionTimerVal := time.Duration(evictionInterval)
+	InitNrfCaching(evictionTimerVal*time.Second, nrfDbCallback)
+
+	// Cache Miss for dnn - 'internet'
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "010203"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	expectedCallCount++
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	// Cache hit scenario
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	// Cache Miss for dnn 'ims'
+	param = Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("ims"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "010203"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	expectedCallCount++
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	// Cache Miss for dnn 'internet' sd '0a0b0c'
+	param = Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "0a0b0c"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	expectedCallCount++
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	DisableNrfCaching()
+}
+
+func TestCacheMissOnTTlExpiry(t *testing.T) {
+	var result models.SearchResult
+	var err error
+
+	expectedCallCount := nrfDbCallbackCallCount
+
+	evictionTimerVal := time.Duration(evictionInterval)
+	InitNrfCaching(evictionTimerVal*time.Second, nrfDbCallback)
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, nil)
+	expectedCallCount++
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Errorf("nrfDbCallbackCallCount: expected = %d, current = %d",
+			expectedCallCount, nrfDbCallbackCallCount)
+	}
+
+	t.Log("wait for profile validity timeout")
+	time.Sleep(65 * time.Second)
+
+	// Cache Miss for dnn 'internet' sd '0a0b0c' as ttl expired..
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "0a0b0c"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	expectedCallCount++
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Errorf("nrfDbCallbackCallCount: expected = %d, current = %d",
+			expectedCallCount, nrfDbCallbackCallCount)
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Errorf("nrfDbCallbackCallCount: expected = %d, current = %d",
+			expectedCallCount, nrfDbCallbackCallCount)
+	}
+
+	DisableNrfCaching()
+}
+
+func TestCacheEviction(t *testing.T) {
+	var result models.SearchResult
+	var err error
+
+	evictionTimerVal := time.Duration(evictionInterval)
+	InitNrfCaching(evictionTimerVal*time.Second, nrfDbCallback)
+
+	// Cache Miss for dnn 'internet' sd '0a0b0c' as ttl expired..
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "010203"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+
+	validityPeriod = 30
+	param = Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("ims"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "010203"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+
+	validityPeriod = 90
+	param = Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "0a0b0c"}})),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+
+	if len(result.NfInstances) == 0 {
+		t.Errorf("nf instances len 0")
+	}
+
+	t.Log("wait for eviction timeout")
+
+	time.Sleep(125 * time.Second)
+
+	DisableNrfCaching()
+}
+
+func TestCacheConcurrency(t *testing.T) {
+
+	evictionTimerVal := time.Duration(evictionInterval)
+	InitNrfCaching(evictionTimerVal*time.Second, nrfDbCallback)
+
+	n := 100
+	wg := sync.WaitGroup{}
+	wg.Add(n)
+
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		ServiceNames: optional.NewInterface([]models.ServiceName{models.ServiceName_NSMF_PDUSESSION}),
+		Dnn:          optional.NewString("internet"),
+		Snssais:      optional.NewInterface(util.MarshToJsonString([]models.Snssai{{Sst: 1, Sd: "010203"}})),
+	}
+
+	expectedCallCount := nrfDbCallbackCallCount + 1
+
+	errCh := make(chan error)
+
+	for i := 0; i < n; i++ {
+		go func() {
+			_, err := SearchNFInstances("testNrf", models.NfType_SMF, models.NfType_AMF, &param)
+
+			if err != nil {
+				errCh <- err
+			}
+			wg.Done()
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Errorf("test timed out")
+	case e := <-errCh:
+		t.Errorf("error %s", e.Error())
+
+	}
+
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Errorf("nrfDbCallbackCallCount: expected = %d, current = %d",
+			expectedCallCount, nrfDbCallbackCallCount)
+	}
+
+	DisableNrfCaching()
+}
+
+func TestAusfMatchFilters(t *testing.T) {
+	evictionTimerVal := time.Duration(evictionInterval)
+	InitNrfCaching(evictionTimerVal*time.Second, nrfDbCallback)
+
+	// Cache Miss for dnn - 'internet'
+	param := Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		Supi: optional.NewString("123456789040001"),
+	}
+
+	expectedCallCount := nrfDbCallbackCallCount
+	expectedCallCount++
+
+	result, err := SearchNFInstances("testNrf", models.NfType_AUSF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_AUSF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+
+	param = Nnrf_NFDiscovery.SearchNFInstancesParamOpts{
+		Supi: optional.NewString("imsi-223456789041111"),
+	}
+
+	result, err = SearchNFInstances("testNrf", models.NfType_AUSF, models.NfType_AMF, &param)
+
+	if err != nil {
+		t.Errorf("test failed, %s", err.Error())
+	}
+	if len(result.NfInstances) == 0 {
+		t.Error("nrf search did not return any records")
+	}
+	if expectedCallCount != nrfDbCallbackCallCount {
+		t.Error("Unexpected nrfDbCallbackCallCount")
+	}
+	DisableNrfCaching()
+}

--- a/nrfcache/nrf_cache_test.go
+++ b/nrfcache/nrf_cache_test.go
@@ -8,14 +8,15 @@ package nrf_cache
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/antihax/optional"
-	"github.com/omec-project/amf/util"
-	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
-	"github.com/omec-project/openapi/models"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/antihax/optional"
+	"github.com/omec-project/nrf/util"
+	"github.com/omec-project/openapi/Nnrf_NFDiscovery"
+	"github.com/omec-project/openapi/models"
 )
 
 var nfProfilesDb map[string]string

--- a/util/util.go
+++ b/util/util.go
@@ -9,6 +9,10 @@
 package util
 
 import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/omec-project/nrf/logger"
 	"github.com/omec-project/path_util"
 )
 
@@ -19,3 +23,26 @@ var (
 	NrfPemPath = path_util.Free5gcPath("free5gc/support/TLS/nrf.pem")
 	NrfKeyPath = path_util.Free5gcPath("free5gc/support/TLS/nrf.key")
 )
+
+func MarshToJsonString(v interface{}) (result []string) {
+	types := reflect.TypeOf(v)
+	val := reflect.ValueOf(v)
+	if types.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			tmp, err := json.Marshal(val.Index(i).Interface())
+			if err != nil {
+				logger.UtilLog.Errorf("Marshal error: %+v", err)
+			}
+
+			result = append(result, string(tmp))
+		}
+	} else {
+		tmp, err := json.Marshal(v)
+		if err != nil {
+			logger.UtilLog.Errorf("Marshal error: %+v", err)
+		}
+
+		result = append(result, string(tmp))
+	}
+	return
+}


### PR DESCRIPTION
This PR Implements the following :-

1) Cache for storing the NF Profiles retrieved from the NRF via NRF NF Discovery Procedure.
2) Cache entries deletion after expiry of validity period.
3) In case of Cache miss , NRF is queried for NF Profile.