### PR TITLE
chore: Enables gofmt linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -216,7 +216,7 @@ linters-settings:
 
 linters:
   enable:
-    # - gofmt
+    - gofmt
     # - govet
     # - errcheck
     # - staticcheck

--- a/nrfcache/nrf_cache_test.go
+++ b/nrfcache/nrf_cache_test.go
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Open Networking Foundation <info@opennetworking.org>
 //
 // SPDX-License-Identifier: Apache-2.0
-//
 package nrf_cache
 
 import (


### PR DESCRIPTION
# Description

This PR enables the go fmt lint check and makes the necessary change to satisfy it.