### PR TITLE
Enable fieldalignment go vet check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,8 +169,6 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
     # enable all analyzers
     enable-all: true
-    disable:
-     - fieldalignment
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/context/search_nf_instance.go
+++ b/context/search_nf_instance.go
@@ -32,7 +32,6 @@ type SearchNFInstances struct {
 	UeIpv4Address           string               `form:"ue-ipv4-address" `
 	IPDomain                string               `form:"ip-domain" `
 	UeIpv6Prefix            string               `form:"ue-ipv6-prefix" `
-	PgwInd                  bool                 `form:"pgw-ind" `
 	Pgw                     string               `form:"pgw" `
 	Gpsi                    string               `form:"gpsi" `
 	ExternalGroupIdentity   string               `form:"external-group-identity" `
@@ -40,10 +39,11 @@ type SearchNFInstances struct {
 	RoutingIndicator        string               `form:"routing-indicator" `
 	GroupIDList             []string             `form:"group-id-list" `
 	DnaiList                []string             `form:"dnai-list" `
-	SupportedFeatures       []string             `form:"supported-features" `
-	UpfIwkEpsInd            bool                 `form:"upf-iwk-eps-ind" `
 	ChfSupportedPlmn        models.PlmnId        `form:"chf-supported-plmn" `
 	PreferredLocality       string               `form:"preferred-locality" `
 	AccessType              models.AccessType    `form:"access-type" `
+	SupportedFeatures       []string             `form:"supported-features" `
+	UpfIwkEpsInd            bool                 `form:"upf-iwk-eps-ind" `
+	PgwInd                  bool                 `form:"pgw-ind" `
 	// IfNoneMatch             string            `form:"target-nf-type" `
 }

--- a/context/search_nf_instance.go
+++ b/context/search_nf_instance.go
@@ -35,13 +35,13 @@ type SearchNFInstances struct {
 	Pgw                     string               `form:"pgw" `
 	Gpsi                    string               `form:"gpsi" `
 	ExternalGroupIdentity   string               `form:"external-group-identity" `
-	DataSet                 models.DataSetId     `form:"data-set" `
 	RoutingIndicator        string               `form:"routing-indicator" `
+	PreferredLocality       string               `form:"preferred-locality" `
+	DataSet                 models.DataSetId     `form:"data-set" `
+	ChfSupportedPlmn        models.PlmnId        `form:"chf-supported-plmn" `
+	AccessType              models.AccessType    `form:"access-type" `
 	GroupIDList             []string             `form:"group-id-list" `
 	DnaiList                []string             `form:"dnai-list" `
-	ChfSupportedPlmn        models.PlmnId        `form:"chf-supported-plmn" `
-	PreferredLocality       string               `form:"preferred-locality" `
-	AccessType              models.AccessType    `form:"access-type" `
 	SupportedFeatures       []string             `form:"supported-features" `
 	UpfIwkEpsInd            bool                 `form:"upf-iwk-eps-ind" `
 	PgwInd                  bool                 `form:"pgw-ind" `

--- a/factory/config.go
+++ b/factory/config.go
@@ -44,12 +44,12 @@ type Configuration struct {
 	Sbi                   *Sbi              `yaml:"sbi,omitempty"`
 	MongoDBName           string            `yaml:"MongoDBName"`
 	MongoDBUrl            string            `yaml:"MongoDBUrl"`
-	MongoDBStreamEnable   bool              `yaml:"mongoDBStreamEnable"`
-	NfProfileExpiryEnable bool              `yaml:"nfProfileExpiryEnable"`
 	DefaultPlmnId         models.PlmnId     `yaml:"DefaultPlmnId"`
 	ServiceNameList       []string          `yaml:"serviceNameList,omitempty"`
 	PlmnSupportList       []PlmnSupportItem `yaml:"plmnSupportList,omitempty"`
 	NfKeepAliveTime       int32             `yaml:"nfKeepAliveTime,omitempty"`
+	MongoDBStreamEnable   bool              `yaml:"mongoDBStreamEnable"`
+	NfProfileExpiryEnable bool              `yaml:"nfProfileExpiryEnable"`
 }
 
 type PlmnSupportItem struct {

--- a/nrfcache/nrf_cache.go
+++ b/nrfcache/nrf_cache.go
@@ -20,8 +20,8 @@ const defaultNfProfileTTl = time.Minute
 
 type NfProfileItem struct {
 	nfProfile  *models.NfProfile
-	ttl        time.Duration
 	expiryTime time.Time
+	ttl        time.Duration
 	index      int // index of the entry in the priority queue
 }
 
@@ -122,13 +122,13 @@ type NrfCache struct {
 
 	priorityQ *NfProfilePriorityQ // sorted by expiry time
 
-	evictionInterval time.Duration // timer interval in which the cache is checked for eviction of expired entries
-
 	evictionTicker *time.Ticker
+
+	done chan struct{}
 
 	nrfDiscoveryQueryCb NrfDiscoveryQueryCb // nrf query callback
 
-	done chan struct{}
+	evictionInterval time.Duration // timer interval in which the cache is checked for eviction of expired entries
 
 	mutex sync.RWMutex
 }
@@ -287,11 +287,10 @@ func NewNrfCache(duration time.Duration, dbqueryCb NrfDiscoveryQueryCb) *NrfCach
 }
 
 type NrfMasterCache struct {
+	nrfDiscoveryQueryCb NrfDiscoveryQueryCb
 	nfTypeToCacheMap    map[models.NfType]*NrfCache
 	evictionInterval    time.Duration
-	nrfDiscoveryQueryCb NrfDiscoveryQueryCb
-
-	mutex sync.Mutex
+	mutex               sync.Mutex
 }
 
 func (c *NrfMasterCache) GetNrfCacheInstance(targetNfType models.NfType) *NrfCache {


### PR DESCRIPTION
Enable `fieldalignment` go vet check in CI
`fieldalignment` defines an Analyzer that detects structs that would use less memory if their fields were sorted.