### PR TITLE
Move Decode from TimeDecode repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/omec-project/TimeDecode v1.1.0
 	github.com/omec-project/config5g v1.2.0
 	github.com/omec-project/http2_util v1.1.0
 	github.com/omec-project/logger_util v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,6 @@ github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v6
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/TimeDecode v1.1.0 h1:1vXQhaYeOkKwWC8x+kPsOrbnFkiZi8e9U5c4IbAI3tM=
-github.com/omec-project/TimeDecode v1.1.0/go.mod h1:yqMSNEIvj60RA9vGmwqsemuSA4+J23NVg91Xy+1Dfcs=
 github.com/omec-project/config5g v1.2.0 h1:fyIg+1LZ9jn8DTkVUbD4jyxA4FgMICdIBwZVnzCyMd4=
 github.com/omec-project/config5g v1.2.0/go.mod h1:AWFzCbbgCBx/iJwt+zWbpDGLHRpFzg24OYHqIkdcMVA=
 github.com/omec-project/http2_util v1.1.0 h1:8H2NME/V8iONth8TlyK/3w4pguAzaeUnEv9pmeAocwQ=

--- a/management/api_management.go
+++ b/management/api_management.go
@@ -13,9 +13,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/omec-project/TimeDecode"
 	"github.com/omec-project/nrf/dbadapter"
 	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/nrf/util"
 	"github.com/omec-project/openapi/models"
 )
 
@@ -60,7 +60,7 @@ func getUdrInfo() map[string]models.UdrInfo {
 	filter := bson.M{"nfType": "UDR"}
 
 	UDR, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	UDRStruct, err := TimeDecode.Decode(UDR, time.RFC3339)
+	UDRStruct, err := util.Decode(UDR, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -85,7 +85,7 @@ func getUdmInfo() map[string]models.UdmInfo {
 	filter := bson.M{"nfType": "UDM"}
 
 	UDM, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	UDMStruct, err := TimeDecode.Decode(UDM, time.RFC3339)
+	UDMStruct, err := util.Decode(UDM, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -110,7 +110,7 @@ func getAusfInfo() map[string]models.AusfInfo {
 	filter := bson.M{"nfType": "AUSF"}
 
 	AUSF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	AUSFStruct, err := TimeDecode.Decode(AUSF, time.RFC3339)
+	AUSFStruct, err := util.Decode(AUSF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -134,7 +134,7 @@ func getAmfInfo() map[string]models.AmfInfo {
 	filter := bson.M{"nfType": "AMF"}
 
 	AMF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	AMFStruct, err := TimeDecode.Decode(AMF, time.RFC3339)
+	AMFStruct, err := util.Decode(AMF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -158,7 +158,7 @@ func getSmfInfo() map[string]models.SmfInfo {
 	filter := bson.M{"nfType": "SMF"}
 
 	SMF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	SMFStruct, err := TimeDecode.Decode(SMF, time.RFC3339)
+	SMFStruct, err := util.Decode(SMF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -182,7 +182,7 @@ func getUpfInfo() map[string]models.UpfInfo {
 	filter := bson.M{"nfType": "UPF"}
 
 	UPF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	UPFStruct, err := TimeDecode.Decode(UPF, time.RFC3339)
+	UPFStruct, err := util.Decode(UPF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -206,7 +206,7 @@ func getPcfInfo() map[string]models.PcfInfo {
 	filter := bson.M{"nfType": "PCF"}
 
 	PCF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	PCFStruct, err := TimeDecode.Decode(PCF, time.RFC3339)
+	PCFStruct, err := util.Decode(PCF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -230,7 +230,7 @@ func getBsfInfo() map[string]models.BsfInfo {
 	filter := bson.M{"nfType": "BSF"}
 
 	BSF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	BSFStruct, err := TimeDecode.Decode(BSF, time.RFC3339)
+	BSFStruct, err := util.Decode(BSF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}
@@ -254,7 +254,7 @@ func getChfInfo() map[string]models.ChfInfo {
 	filter := bson.M{"nfType": "CHF"}
 
 	CHF, _ := dbadapter.DBClient.RestfulAPIGetMany(collName, filter)
-	CHFStruct, err := TimeDecode.Decode(CHF, time.RFC3339)
+	CHFStruct, err := util.Decode(CHF, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Error(err)
 	}

--- a/producer/nf_discovery.go
+++ b/producer/nf_discovery.go
@@ -18,10 +18,10 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
-	"github.com/omec-project/TimeDecode"
 	"github.com/omec-project/nrf/context"
 	"github.com/omec-project/nrf/dbadapter"
 	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/nrf/util"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/httpwrapper"
 )
@@ -92,7 +92,7 @@ func NFDiscoveryProcedure(queryParameters url.Values) (response *models.SearchRe
 	// nfProfile data for response
 	var nfProfilesStruct []models.NfProfile
 
-	nfProfilesStruct, err := TimeDecode.Decode(nfProfilesRaw, time.RFC3339)
+	nfProfilesStruct, err := util.Decode(nfProfilesRaw, time.RFC3339)
 	if err != nil {
 		logger.DiscoveryLog.Warnln("NF Profile Raw decode error: ", nfProfilesStruct)
 	}

--- a/producer/nf_management.go
+++ b/producer/nf_management.go
@@ -16,11 +16,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"go.mongodb.org/mongo-driver/bson"
 
-	"github.com/omec-project/TimeDecode"
 	nrf_context "github.com/omec-project/nrf/context"
 	"github.com/omec-project/nrf/dbadapter"
 	"github.com/omec-project/nrf/factory"
 	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/nrf/util"
 	"github.com/omec-project/openapi/Nnrf_NFManagement"
 	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/util/httpwrapper"
@@ -260,7 +260,7 @@ func NFDeregisterProcedure(nfInstanceID string) (problemDetails *models.ProblemD
 	dbadapter.DBClient.RestfulAPIDeleteMany(collName, filter)
 
 	// nfProfile data for response
-	nfProfiles, err := TimeDecode.Decode(nfProfilesRaw, time.RFC3339)
+	nfProfiles, err := util.Decode(nfProfilesRaw, time.RFC3339)
 	if err != nil {
 		logger.ManagementLog.Warnln("Time decode error: ", err)
 		problemDetails = &models.ProblemDetails{
@@ -323,7 +323,7 @@ func UpdateNFInstanceProcedure(nfInstanceID string, patchJSON []byte) (response 
 			nf,
 		}
 
-		nfProfiles, decodeErr := TimeDecode.Decode(nfProfilesRaw, time.RFC3339)
+		nfProfiles, decodeErr := util.Decode(nfProfilesRaw, time.RFC3339)
 		if decodeErr != nil {
 			logger.ManagementLog.Info(decodeErr.Error())
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -11,8 +11,11 @@ package util
 import (
 	"encoding/json"
 	"reflect"
+	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/openapi/models"
 	"github.com/omec-project/path_util"
 )
 
@@ -45,4 +48,37 @@ func MarshToJsonString(v interface{}) (result []string) {
 		result = append(result, string(tmp))
 	}
 	return
+}
+
+// Decode - Only support []map[string]interface to []models.NfProfile
+func Decode(source interface{}, format string) ([]models.NfProfile, error) {
+	var target []models.NfProfile
+
+	// config mapstruct
+	stringToDateTimeHook := func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if t == reflect.TypeOf(time.Time{}) && f == reflect.TypeOf("") {
+			return time.Parse(format, data.(string))
+		}
+		return data, nil
+	}
+
+	config := mapstructure.DecoderConfig{
+		DecodeHook: stringToDateTimeHook,
+		Result:     &target,
+	}
+
+	decoder, err := mapstructure.NewDecoder(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decode result to NfProfile structure
+	err = decoder.Decode(source)
+	if err != nil {
+		return nil, err
+	}
+	return target, nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2021 Open Networking Foundation <info@opennetworking.org>
+// Copyright 2019 free5GC.org
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !debug
+// +build !debug
+
+package util
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/omec-project/openapi/models"
+)
+
+func TestDecode(t *testing.T) {
+	//Set time
+	date := time.Now()
+	dateFormat, _ := time.Parse(time.RFC3339, date.Format(time.RFC3339))
+
+	testData1 := map[string]interface{}{
+		"NfInstanceId":   "0",
+		"NfType":         models.NfType_NRF,
+		"NfStatus":       models.NfStatus_REGISTERED,
+		"HeartBeatTimer": 10,
+		"PlmnList": &[]models.PlmnId{ // Pattern: '^[0-9]{3}[0-9]{2,3}$'
+			{
+				Mcc: "111",
+				Mnc: "111",
+			},
+		},
+		"SNssais": &[]models.Snssai{ // range 0-255
+			{
+				Sst: 222,
+				Sd:  "SNssais",
+			},
+		},
+		"NsiList": []string{
+			"nsi0",
+		},
+		"Fqdn":          "fqdn",
+		"InterPlmnFqdn": "InterPlmnFqdn",
+		"Ipv4Addresses": []string{
+			"140.113.1.1",
+		},
+		"Ipv6Addresses": []string{
+			"fc00::",
+		},
+		"AllowedPlmns": &[]models.PlmnId{
+			{
+				Mcc: "111",
+				Mnc: "111",
+			},
+		},
+		"AllowedNfTypes": []models.NfType{
+			models.NfType_NRF,
+		},
+		"AllowedNfDomains": []string{
+			"nfdomain1",
+		},
+		"AllowedNssais": &[]models.Snssai{
+			{
+				Sst: 333,
+				Sd:  "AllowedNssais",
+			},
+		},
+		"Priority":             1,
+		"Capacity":             1,
+		"Load":                 1,
+		"Locality":             "NCTU",
+		"UdrInfo":              &models.UdrInfo{},
+		"UdmInfo":              &models.UdmInfo{},
+		"AusfInfo":             &models.AusfInfo{},
+		"AmfInfo":              &models.AmfInfo{},
+		"SmfInfo":              &models.SmfInfo{},
+		"UpfInfo":              &models.UpfInfo{},
+		"PcfInfo":              &models.PcfInfo{},
+		"BsfInfo":              &models.BsfInfo{},
+		"ChfInfo":              &models.ChfInfo{},
+		"NrfInfo":              &models.NrfInfo{},
+		"CustomInfo":           &map[string]interface{}{},
+		"RecoveryTime":         &dateFormat,
+		"NfServicePersistence": true,
+		"NfServices": &[]models.NfService{
+			{
+				ServiceName:     models.ServiceName_NNRF_DISC,
+				NfServiceStatus: models.NfServiceStatus_REGISTERED,
+				AllowedNfDomains: []string{
+					"nfdomain3",
+					"nfdomain4",
+				},
+			},
+		},
+	}
+
+	var source = []map[string]interface{}{
+		testData1,
+	}
+
+	target, err := Decode(source, time.RFC3339)
+	if err != nil {
+		t.Log(err)
+	}
+
+	log.Printf("%+v", target)
+}


### PR DESCRIPTION
The `TimeDecode` repo has a single file with a single function in it (`Decode`) and this function is only used by the `nrf`. This PR moves that function and its test from `TimeDecode` repo to `nrf/util` this repo