### PR TITLE
chore: Parameterise webui URL

### DIFF
--- a/factory/config.go
+++ b/factory/config.go
@@ -44,6 +44,7 @@ type Configuration struct {
 	Sbi                   *Sbi              `yaml:"sbi,omitempty"`
 	MongoDBName           string            `yaml:"MongoDBName"`
 	MongoDBUrl            string            `yaml:"MongoDBUrl"`
+	WebuiUri              string            `yaml:"webuiUri"`
 	DefaultPlmnId         models.PlmnId     `yaml:"DefaultPlmnId"`
 	ServiceNameList       []string          `yaml:"serviceNameList,omitempty"`
 	PlmnSupportList       []PlmnSupportItem `yaml:"plmnSupportList,omitempty"`

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -40,11 +40,14 @@ func InitConfigFactory(f string) error {
 		if yamlErr := yaml.Unmarshal(content, &NrfConfig); yamlErr != nil {
 			return yamlErr
 		}
+		if NrfConfig.Configuration.WebuiUri == "" {
+			NrfConfig.Configuration.WebuiUri = "webui:9876"
+		}
 		initLog.Infof("DefaultPlmnId Mnc %v , Mcc %v \n", NrfConfig.Configuration.DefaultPlmnId.Mnc, NrfConfig.Configuration.DefaultPlmnId.Mcc)
 		roc := os.Getenv("MANAGED_BY_CONFIG_POD")
 		if roc == "true" {
 			initLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-			commChannel := client.ConfigWatcher()
+			commChannel := client.ConfigWatcher(NrfConfig.Configuration.WebuiUri)
 			ManagedByConfigPod = true
 			go NrfConfig.updateConfig(commChannel)
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/omec-project/config5g v1.3.0
+	github.com/omec-project/config5g v1.3.1
 	github.com/omec-project/http2_util v1.2.0
 	github.com/omec-project/logger_util v1.2.0
 	github.com/omec-project/openapi v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v6
 github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
-github.com/omec-project/config5g v1.3.0 h1:e/oMZlQsef8bOpHT56uAMKIag3epCOW0jpmyadFC+30=
-github.com/omec-project/config5g v1.3.0/go.mod h1:h6eaDdWEY7432L9rZAg1Za6HrvFvDWRNolAn5GK/5No=
+github.com/omec-project/config5g v1.3.1 h1:hSvFHXh/J0mslsWR82PPnmpF0WzkmLa6AOdvEPve9e8=
+github.com/omec-project/config5g v1.3.1/go.mod h1:lN/Jc2BZkE/smOGPCXxeo1dJ7s+s9Wgp34crNLH4YeE=
 github.com/omec-project/http2_util v1.2.0 h1:ggQ1GjY2x6VRpKuRhZj0t9dh6eISY6LRBv4rlMD++8s=
 github.com/omec-project/http2_util v1.2.0/go.mod h1:KLgvU3o7qmG/i5XO/qITscFql2tWCAmjE6glX+dxe7M=
 github.com/omec-project/logger_conf v1.1.1 h1:qo0cF5gnPfth8wy+I/QjiOx+F5jB6h4GLSOdyS+ted8=

--- a/nrfTest/nrfcfg.yaml
+++ b/nrfTest/nrfcfg.yaml
@@ -7,6 +7,7 @@ info:
 configuration:
   MongoDBName: free5gc # database name in MongoDB
   MongoDBUrl: mongodb://127.0.0.1:27017 # a valid URL of the mongodb
+  webuiUri: webui:9876 # a valid URI of Webui
   sbi: # Service-based interface information
     scheme: http # the protocol for sbi (http or https)
     registerIPv4: 127.0.0.10 # IP used to serve NFs or register to another NRF


### PR DESCRIPTION
Config5g library was including the hard coded Webui URL in ConfigWatcher function which is used by several NFs.
PR: https://github.com/omec-project/config5g/pull/35 in Config5G  library allows to change weburi URL. 
Based on that change [this PR](https://github.com/omec-project/nrf/pull/75) provides to pass the Weburi URL in NRF. 

Note: https://github.com/omec-project/config5g/pull/35 should be merged before this PR.