### PR TITLE
feat: implement polling for NF configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ profile from the database and returns it to the caller.
 
 
 ## NRF block diagram
-![UDM Block Diagram](/docs/images/README-NRF.png)
+![NRF Block Diagram](/docs/images/README-NRF.png)
 
 ## Supported Features
 - Registration of Network Functions
@@ -32,6 +32,21 @@ profile from the database and returns it to the caller.
 - NRF cache library which can be used by modules to avoid frequent queries to NRF
 
 Compliance of the 5G Network functions can be found at [5G Compliance](https://docs.sd-core.opennetworking.org/main/overview/3gpp-compliance-5g.html)
+
+## Dynamic Network configuration (via webconsole)
+
+NRF polls the webconsole every 5 seconds to fetch the latest PLMN configuration.
+
+### Setting Up Polling
+
+Include the `webuiUri` of the webconsole in the configuration file
+```
+configuration:
+  ...
+  webuiUri: https://webui:5001 # or http://webui:5001
+  ...
+```
+The scheme (http:// or https://) must be explicitly specified.
 
 ## Reach out to us thorugh
 

--- a/context/context.go
+++ b/context/context.go
@@ -15,24 +15,32 @@ import (
 	"github.com/omec-project/openapi/models"
 )
 
-var (
+type NRFContext struct {
 	NrfNfProfile     models.NfProfile
 	Nrf_NfInstanceID string
-)
+	PlmnList         []models.PlmnId
+}
 
-func InitNrfContext() {
+var nrfContext NRFContext
+
+func Init() {
+	InitNrfContext(&nrfContext)
+}
+
+func InitNrfContext(context *NRFContext) {
 	config := factory.NrfConfig
 	logger.InitLog.Infof("nrfconfig Info: Version[%s] Description[%s]", config.Info.Version, config.Info.Description)
 	configuration := config.Configuration
 
-	NrfNfProfile.NfInstanceId = uuid.New().String()
-	NrfNfProfile.NfType = models.NfType_NRF
-	NrfNfProfile.NfStatus = models.NfStatus_REGISTERED
+	context.NrfNfProfile.NfInstanceId = uuid.New().String()
+	context.NrfNfProfile.NfType = models.NfType_NRF
+	context.NrfNfProfile.NfStatus = models.NfStatus_REGISTERED
 
 	serviceNameList := configuration.ServiceNameList
-
+	context.PlmnList = []models.PlmnId{}
 	NFServices := InitNFService(serviceNameList, config.Info.Version)
-	NrfNfProfile.NfServices = &NFServices
+	context.NrfNfProfile.NfServices = &NFServices
+	logger.ContextLog.Infoln("nrf context:", context)
 }
 
 func InitNFService(srvNameList []string, version string) []models.NfService {
@@ -63,4 +71,8 @@ func InitNFService(srvNameList []string, version string) []models.NfService {
 		}
 	}
 	return NFServices
+}
+
+func GetSelf() *NRFContext {
+	return &nrfContext
 }

--- a/factory/config.go
+++ b/factory/config.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"strconv"
 
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
 	"github.com/omec-project/nrf/logger"
 	"github.com/omec-project/openapi/models"
 	utilLogger "github.com/omec-project/util/logger"
@@ -46,7 +45,6 @@ type Configuration struct {
 	MongoDBName           string            `yaml:"MongoDBName"`
 	MongoDBUrl            string            `yaml:"MongoDBUrl"`
 	WebuiUri              string            `yaml:"webuiUri"`
-	DefaultPlmnId         models.PlmnId     `yaml:"DefaultPlmnId"`
 	ServiceNameList       []string          `yaml:"serviceNameList,omitempty"`
 	PlmnSupportList       []PlmnSupportItem `yaml:"plmnSupportList,omitempty"`
 	NfKeepAliveTime       int32             `yaml:"nfKeepAliveTime,omitempty"`
@@ -71,8 +69,6 @@ type TLS struct {
 	PEM string `yaml:"pem,omitempty"`
 	Key string `yaml:"key,omitempty"`
 }
-
-var MinConfigAvailable bool
 
 func (c *Config) GetVersion() string {
 	if c.Info != nil && c.Info.Version != "" {
@@ -137,30 +133,4 @@ func (c *Config) GetSbiRegisterAddr() string {
 
 func (c *Config) GetSbiUri() string {
 	return c.GetSbiScheme() + "://" + c.GetSbiRegisterAddr()
-}
-
-func (c *Config) UpdateConfig(commChannel chan *protos.NetworkSliceResponse) bool {
-	for rsp := range commChannel {
-		logger.GrpcLog.Infoln("received updateConfig in the nrf app: ", rsp)
-		for _, ns := range rsp.NetworkSlice {
-			logger.GrpcLog.Infoln("Network Slice Name", ns.Name)
-			if ns.Site != nil {
-				logger.GrpcLog.Infoln("Network Slice has site name present")
-				site := ns.Site
-				logger.GrpcLog.Infoln("Site name", site.SiteName)
-				if site.Plmn != nil {
-					logger.GrpcLog.Infoln("Plmn mcc", site.Plmn.Mcc)
-					plmn := PlmnSupportItem{}
-					plmn.PlmnId.Mnc = site.Plmn.Mnc
-					plmn.PlmnId.Mcc = site.Plmn.Mcc
-					NrfConfig.Configuration.PlmnSupportList = append(NrfConfig.Configuration.PlmnSupportList, plmn)
-				} else {
-					logger.GrpcLog.Infoln("Plmn not present in the message")
-				}
-			}
-		}
-		logger.GrpcLog.Infoln("minimum config Available")
-		MinConfigAvailable = true
-	}
-	return true
 }

--- a/factory/nrf_config_test.go
+++ b/factory/nrf_config_test.go
@@ -18,7 +18,7 @@ func TestGetDefaultWebuiUrl(t *testing.T) {
 		t.Logf("error in InitConfigFactory: %v", err)
 	}
 	got := NrfConfig.Configuration.WebuiUri
-	want := "webui:9876"
+	want := "http://webui:9876"
 	assert.Equal(t, got, want, "The webui URL is not correct.")
 }
 
@@ -28,6 +28,6 @@ func TestGetCustomWebuiUrl(t *testing.T) {
 		t.Logf("error in InitConfigFactory: %v", err)
 	}
 	got := NrfConfig.Configuration.WebuiUri
-	want := "myspecialwebui:9872"
+	want := "https://myspecialwebui:9872"
 	assert.Equal(t, got, want, "The webui URL is not correct.")
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -23,6 +23,8 @@ var (
 	GinLog         *zap.SugaredLogger
 	GrpcLog        *zap.SugaredLogger
 	UtilLog        *zap.SugaredLogger
+	PollConfigLog  *zap.SugaredLogger
+	ContextLog     *zap.SugaredLogger
 	atomicLevel    zap.AtomicLevel
 )
 
@@ -62,6 +64,8 @@ func init() {
 	GinLog = log.Sugar().With("component", "NRF", "category", "GIN")
 	GrpcLog = log.Sugar().With("component", "NRF", "category", "GRPC")
 	UtilLog = log.Sugar().With("component", "NRF", "category", "Util")
+	PollConfigLog = log.Sugar().With("component", "NRF", "category", "PollConfig")
+	ContextLog = log.Sugar().With("component", "NRF", "category", "ctx")
 }
 
 func GetLogger() *zap.Logger {

--- a/nrfTest/nrfcfg.yaml
+++ b/nrfTest/nrfcfg.yaml
@@ -16,9 +16,6 @@ configuration:
     tls: # the local path of TLS key
       pem: config/TLS/nrf.pem # NRF TLS Certificate
       key: config/TLS/nrf.key # NRF TLS Private key
-  DefaultPlmnId:
-    mcc: 208 # Mobile Country Code (3 digits string, digit: 0~9)
-    mnc: 93 # Mobile Network Code (2 or 3 digits string, digit: 0~9)
   serviceNameList: # the SBI services provided by this NRF, refer to TS 29.510
     - nnrf-nfm # Nnrf_NFManagement service
     - nnrf-disc # Nnrf_NFDiscovery service

--- a/nrfTest/nrfcfg_with_custom_webui_url.yaml
+++ b/nrfTest/nrfcfg_with_custom_webui_url.yaml
@@ -6,4 +6,4 @@ info:
   description: NRF initial local configuration
 
 configuration:
-  webuiUri: myspecialwebui:9872 # a valid URI of Webui
+  webuiUri: https://myspecialwebui:9872 # a valid URI of Webui

--- a/polling/nf_configuration.go
+++ b/polling/nf_configuration.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2025 Canonical Ltd
+
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	nrfContext "github.com/omec-project/nrf/context"
+	"github.com/omec-project/nrf/factory"
+	"github.com/omec-project/nrf/logger"
+	"github.com/omec-project/openapi/models"
+)
+
+const (
+	INITIAL_POLLING_INTERVAL = 5 * time.Second
+	POLLING_MAX_BACKOFF      = 40 * time.Second
+	POLLING_BACKOFF_FACTOR   = 2
+	POLLING_PATH             = "/nfconfig/plmn"
+)
+
+// PollNetworkConfig makes a HTTP GET request to the webconsole and updates the network configuration
+func PollNetworkConfig() {
+	interval := INITIAL_POLLING_INTERVAL
+	nrfContext := nrfContext.GetSelf()
+
+	for {
+		time.Sleep(interval)
+		newPlmnConfig, err := fetchPlmnConfig()
+		if err != nil {
+			interval = minDuration(interval*time.Duration(POLLING_BACKOFF_FACTOR), POLLING_MAX_BACKOFF)
+			logger.PollConfigLog.Errorf("error polling network configuration. Will retry in %v: ", interval, err)
+			continue
+		}
+		logger.PollConfigLog.Infoln("configuration polled successfully")
+		interval = INITIAL_POLLING_INTERVAL
+		handlePolledPlmnConfig(nrfContext, newPlmnConfig)
+	}
+}
+
+func fetchPlmnConfig() ([]models.PlmnId, error) {
+	pollingEndpoint := factory.NrfConfig.Configuration.WebuiUri + POLLING_PATH
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pollingEndpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET %v failed: %w", pollingEndpoint, err)
+	}
+	defer resp.Body.Close()
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.Contains(contentType, "application/json") {
+		return nil, fmt.Errorf("unexpected Content-Type: got %s, want application/json", contentType)
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		var config []models.PlmnId
+		if err := json.Unmarshal(body, &config); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+		}
+		return config, nil
+
+	case http.StatusBadRequest, http.StatusInternalServerError:
+		return nil, fmt.Errorf("server returned %d error code", resp.StatusCode)
+	default:
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+}
+
+func handlePolledPlmnConfig(nrfContext *nrfContext.NRFContext, newPlmnConfig []models.PlmnId) {
+	if reflect.DeepEqual(nrfContext.PlmnList, newPlmnConfig) {
+		logger.PollConfigLog.Debugln("PLMN config did not change")
+		return
+	}
+	nrfContext.PlmnList = newPlmnConfig
+	logger.PollConfigLog.Infof("PLMN config changed. New PLMN ID list: %v", nrfContext.PlmnList)
+}
+
+func minDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/polling/nf_configuration_test.go
+++ b/polling/nf_configuration_test.go
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025 Canonical Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+/*
+ * NF Polling Unit Tests
+ *
+ */
+
+package polling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omec-project/nrf/factory"
+	"github.com/omec-project/openapi/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchPlmnConfig(t *testing.T) {
+	validPlmnList := []models.PlmnId{
+		{Mcc: "001", Mnc: "01"},
+		{Mcc: "002", Mnc: "02"},
+	}
+	validJson, _ := json.Marshal(validPlmnList)
+
+	tests := []struct {
+		name           string
+		statusCode     int
+		contentType    string
+		responseBody   string
+		expectedError  string
+		expectedResult []models.PlmnId
+	}{
+		{
+			name:           "200 OK with valid JSON",
+			statusCode:     http.StatusOK,
+			contentType:    "application/json",
+			responseBody:   string(validJson),
+			expectedError:  "",
+			expectedResult: validPlmnList,
+		},
+		{
+			name:          "200 OK with invalid Content-Type",
+			statusCode:    http.StatusOK,
+			contentType:   "text/plain",
+			responseBody:  string(validJson),
+			expectedError: "unexpected Content-Type: got text/plain, want application/json",
+		},
+		{
+			name:          "400 Bad Request",
+			statusCode:    http.StatusBadRequest,
+			contentType:   "application/json",
+			responseBody:  "",
+			expectedError: "server returned 400 error code",
+		},
+		{
+			name:          "500 Internal Server Error",
+			statusCode:    http.StatusInternalServerError,
+			contentType:   "application/json",
+			responseBody:  "",
+			expectedError: "server returned 500 error code",
+		},
+		{
+			name:          "Unexpected Status Code 418",
+			statusCode:    418,
+			contentType:   "application/json",
+			responseBody:  "",
+			expectedError: "unexpected status code: 418",
+		},
+		{
+			name:          "200 OK with invalid JSON",
+			statusCode:    http.StatusOK,
+			contentType:   "application/json",
+			responseBody:  "{invalid-json}",
+			expectedError: "failed to parse JSON response:",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, r *http.Request) {
+				accept := r.Header.Get("Accept")
+				assert.Equal(t, "application/json", accept)
+
+				w.Header().Set("Content-Type", tc.contentType)
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.responseBody))
+			}
+			server := httptest.NewServer(http.HandlerFunc(handler))
+			defer server.Close()
+
+			factory.NrfConfig = factory.Config{
+				Configuration: &factory.Configuration{
+					WebuiUri: server.URL,
+				},
+			}
+			fetchedConfig, err := fetchPlmnConfig()
+
+			if tc.expectedError == "" {
+				if err != nil {
+					t.Errorf("expected no error, got `%v`", err)
+				}
+				if !reflect.DeepEqual(tc.expectedResult, fetchedConfig) {
+					t.Errorf("error in fetched config: expected `%v`, got `%v`", tc.expectedResult, fetchedConfig)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error `%v`, got nil", tc.expectedError)
+				}
+				if !strings.Contains(err.Error(), tc.expectedError) {
+					t.Errorf("expected error `%v`, got `%v`", tc.expectedError, err)
+				}
+			}
+
+			factory.NrfConfig.Configuration = nil
+		})
+	}
+}

--- a/service/init.go
+++ b/service/init.go
@@ -16,16 +16,14 @@ import (
 	"syscall"
 	"time"
 
-	grpcClient "github.com/omec-project/config5g/proto/client"
-	protos "github.com/omec-project/config5g/proto/sdcoreConfig"
 	"github.com/omec-project/nrf/accesstoken"
-	nrfContext "github.com/omec-project/nrf/context"
 	"github.com/omec-project/nrf/dbadapter"
 	"github.com/omec-project/nrf/discovery"
 	"github.com/omec-project/nrf/factory"
 	"github.com/omec-project/nrf/logger"
 	"github.com/omec-project/nrf/management"
 	"github.com/omec-project/nrf/metrics"
+	"github.com/omec-project/nrf/polling"
 	openapiLogger "github.com/omec-project/openapi/logger"
 	"github.com/omec-project/util/http2_util"
 	utilLogger "github.com/omec-project/util/logger"
@@ -83,69 +81,8 @@ func (nrf *NRF) Initialize(c *cli.Context) error {
 	if err := factory.CheckConfigVersion(); err != nil {
 		return err
 	}
-
-	factory.NrfConfig.CfgLocation = absPath
-
-	if os.Getenv("MANAGED_BY_CONFIG_POD") == "true" {
-		logger.InitLog.Infoln("MANAGED_BY_CONFIG_POD is true")
-		go manageGrpcClient(factory.NrfConfig.Configuration.WebuiUri)
-	}
-
+	go polling.PollNetworkConfig()
 	return nil
-}
-
-// manageGrpcClient connects the config pod GRPC server and subscribes the config changes.
-// Then it updates NRF configuration.
-func manageGrpcClient(webuiUri string) {
-	var configChannel chan *protos.NetworkSliceResponse
-	var client grpcClient.ConfClient
-	var stream protos.ConfigService_NetworkSliceSubscribeClient
-	var err error
-	count := 0
-	for {
-		if client != nil {
-			if client.CheckGrpcConnectivity() != "READY" {
-				time.Sleep(time.Second * 30)
-				count++
-				if count > 5 {
-					err = client.GetConfigClientConn().Close()
-					if err != nil {
-						logger.InitLog.Infof("failing ConfigClient is not closed properly: %+v", err)
-					}
-					client = nil
-					count = 0
-				}
-				logger.InitLog.Infoln("checking the connectivity readiness")
-				continue
-			}
-
-			if stream == nil {
-				stream, err = client.SubscribeToConfigServer()
-				if err != nil {
-					logger.InitLog.Infof("failing SubscribeToConfigServer: %+v", err)
-					continue
-				}
-			}
-
-			if configChannel == nil {
-				configChannel = client.PublishOnConfigChange(true, stream)
-				logger.InitLog.Infoln("PublishOnConfigChange is triggered")
-				go factory.NrfConfig.UpdateConfig(configChannel)
-				logger.InitLog.Infoln("NRF updateConfig is triggered")
-			}
-
-			time.Sleep(time.Second * 5) // Fixes (avoids) 100% CPU utilization
-		} else {
-			client, err = grpcClient.ConnectToConfigServer(webuiUri)
-			stream = nil
-			configChannel = nil
-			logger.InitLog.Infoln("connecting to config server")
-			if err != nil {
-				logger.InitLog.Errorf("%+v", err)
-			}
-			continue
-		}
-	}
 }
 
 func (nrf *NRF) setLogLevel() {
@@ -225,8 +162,6 @@ func (nrf *NRF) Start() {
 	management.AddService(router)
 
 	go metrics.InitMetrics()
-
-	nrfContext.InitNrfContext()
 
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
This PR implements the new NF configuration system.
The NRF polls the webconsole, through the `/nfconfig/plmn` API endpoint, every 5 seconds to retrieve the most recent supported PLMNs configuration.
This PR removes the usage of `MANAGED_BY_CONFIG_POD` variable, since the configuration is always retrieved from the webconsole.
This PR fixes #207 by checking the PLMN list available from webconsole and removing the `MinConfigAvailable` variable.
This PR removes the `DefaultPlmnId` from factory configuration:
- if a NF registers without providing any PLMN and NRF does not have any PLMN stored, an error is raised and NF registration fails
- if a NF registers without proviving any PLMN and NRF does have PLMNs stored, its configuration is saved in the NF profile and NF registration succeeds
- if a NF registers providing PLMNs, NF registration succeeds (independently of PLMNs stored in NRF)